### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "mihkullorg/lhv-connect",
+  "name": "mihkelallorg/lhv-connect",
   "description": "LHV bank's CONNECT service for Laravel 5",
   "keywords": ["lhv","lhv-connect", "connect", "lhv-bank", "bank"],
-  "homepage": "https://github.com/mihkullorg/lhv-connect",
+  "homepage": "https://github.com/mihkelallorg/lhv-connect",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
README.md and composer.json contain different package names.

README says: composer require mihkelallorg/lhv-connect and installation fails
composer.json says package name is: mihkullorg/lhv-connect
Also github URL is different. 
Also namespaces needed to be changed: Mihkullorg/LhvConnect


Easisest way is to change README.md installation manual, but correct way is to change all, but it may cause problems to other package installers.